### PR TITLE
add colab callback function for display, auto download model checkpoints, and colab notebook

### DIFF
--- a/cfg_sample.py
+++ b/cfg_sample.py
@@ -48,6 +48,12 @@ def resize_and_center_crop(image, size):
     image = image.resize((int(fac * image.size[0]), int(fac * image.size[1])), Image.LANCZOS)
     return TF.center_crop(image, size[::-1])
 
+def callback_fn(info):
+    if info['i'] % 50==0:
+        out = info['pred'].add(1).div(2)
+        save_image(out, f"interm_output_{info['i']:05d}.png")
+        if IS_NOTEBOOK:
+            display.display(display.Image(f"interm_output_{info['i']:05d}.png",height=300))
 
 def main():
     p = argparse.ArgumentParser(description=__doc__,
@@ -131,13 +137,6 @@ def main():
     weights = torch.tensor([1 - sum(weights), *weights], device=device)
 
     torch.manual_seed(args.seed)
-
-    def callback_fn(pred, i):
-        if i % 50==0 or i==args.steps:
-            out = pred.add(1).div(2)
-            save_image(out, f"interm_output_{i:05d}.png")
-            if IS_NOTEBOOK:
-                display.display(display.Image(f"interm_output_{i:05d}.png",height=300))
 
     def cfg_model_fn(x, t):
         n = x.shape[0]
@@ -234,13 +233,6 @@ def run_diffusion_cfg(prompts,images=None,steps=1000,init=None,model="cc12m_1_cf
     weights = torch.tensor([1 - sum(weights), *weights], device=device)
 
     torch.manual_seed(args.seed)
-
-    def callback_fn(pred, i):
-        if i % display_freq==0 or i==args.steps:
-            out = pred.add(1).div(2)
-            save_image(out, f"interm_output_{i:05d}.png")
-            if IS_NOTEBOOK:
-                display.display(display.Image(f"interm_output_{i:05d}.png",height=300))
 
     def cfg_model_fn(x, t):
         n = x.shape[0]

--- a/cfg_sample.py
+++ b/cfg_sample.py
@@ -152,7 +152,7 @@ def main():
         return v
 
     def run(x, steps):
-        return sampling.sample(cfg_model_fn, x, steps, args.eta, {}, callback_fn=callback_fn)
+        return sampling.sample(cfg_model_fn, x, steps, args.eta, {}, callback=callback_fn)
 
     def run_all(n, batch_size):
         x = torch.randn([args.n, 3, side_y, side_x], device=device)
@@ -255,7 +255,7 @@ def run_diffusion_cfg(prompts,images=None,steps=1000,init=None,model="cc12m_1_cf
         return v
 
     def run(x, steps):
-        return sampling.sample(cfg_model_fn, x, steps, args.eta, {}, callback_fn=callback_fn)
+        return sampling.sample(cfg_model_fn, x, steps, args.eta, {}, callback=callback_fn)
 
     def run_all(n, batch_size):
         x = torch.randn([args.n, 3, side_y, side_x], device=device)

--- a/cfg_sample.py
+++ b/cfg_sample.py
@@ -14,6 +14,7 @@ from torch.nn import functional as F
 from torchvision import transforms
 from torchvision.transforms import functional as TF
 from torchvision.utils import save_image
+from tqdm.auto import trange
 
 from CLIP import clip
 from diffusion import get_model, get_models, sampling, utils, download_model
@@ -27,9 +28,6 @@ def isnotebook():
 IS_NOTEBOOK = isnotebook()
 if IS_NOTEBOOK:
     from IPython import display
-    from tqdm.notebook import trange
-else:
-    from tqdm import trange
 
 
 MODULE_DIR = Path(__file__).resolve().parent

--- a/clip_sample.py
+++ b/clip_sample.py
@@ -14,6 +14,7 @@ from torch.nn import functional as F
 from torchvision import transforms
 from torchvision.transforms import functional as TF
 from torchvision.utils import save_image
+from tqdm.auto import trange
 
 from CLIP import clip
 from diffusion import get_model, get_models, sampling, utils, download_model
@@ -28,9 +29,6 @@ def isnotebook():
 IS_NOTEBOOK = isnotebook()
 if IS_NOTEBOOK:
     from IPython import display
-    from tqdm.notebook import trange
-else:
-    from tqdm import trange
 
 
 

--- a/clip_sample.py
+++ b/clip_sample.py
@@ -5,20 +5,36 @@
 import argparse
 from functools import partial
 from pathlib import Path
-
+import os
+from types import SimpleNamespace
 from PIL import Image
 import torch
 from torch import nn
 from torch.nn import functional as F
 from torchvision import transforms
 from torchvision.transforms import functional as TF
-from tqdm import trange
+from torchvision.utils import save_image
 
 from CLIP import clip
-from diffusion import get_model, get_models, sampling, utils
+from diffusion import get_model, get_models, sampling, utils, download_model
+
+
+def isnotebook():
+    try:
+        shell = get_ipython().__class__.__name__
+        return shell=='ZMQInteractiveShell' or shell=='Shell'
+    except NameError:
+        return False      
+IS_NOTEBOOK = isnotebook()
+if IS_NOTEBOOK:
+    from IPython import display
+    from tqdm.notebook import trange
+else:
+    from tqdm import trange
+
+
 
 MODULE_DIR = Path(__file__).resolve().parent
-
 
 class MakeCutouts(nn.Module):
     def __init__(self, cut_size, cutn, cut_pow=1.):
@@ -114,6 +130,8 @@ def main():
     checkpoint = args.checkpoint
     if not checkpoint:
         checkpoint = MODULE_DIR / f'checkpoints/{args.model}.pth'
+    if not os.path.isfile(checkpoint):
+        download_model(args.model, checkpoint)
     model.load_state_dict(torch.load(checkpoint, map_location='cpu'))
     if device.type == 'cuda':
         model = model.half()
@@ -160,6 +178,13 @@ def main():
 
     torch.manual_seed(args.seed)
 
+    def callback_fn(pred, i):
+        if i % 50==0 or i==args.steps:
+            out = pred.add(1).div(2)
+            save_image(out, f"interm_output_{i:05d}.png")
+            if IS_NOTEBOOK:
+                display.display(display.Image(f"interm_output_{i:05d}.png",height=300))
+
     def cond_fn(x, t, pred, clip_embed):
         clip_in = normalize(make_cutouts((pred + 1) / 2))
         image_embeds = clip_model.encode_image(clip_in).view([args.cutn, x.shape[0], -1])
@@ -176,8 +201,127 @@ def main():
             extra_args = {}
             cond_fn_ = partial(cond_fn, clip_embed=clip_embed)
         if not args.clip_guidance_scale:
-            return sampling.sample(model, x, steps, args.eta, extra_args)
-        return sampling.cond_sample(model, x, steps, args.eta, extra_args, cond_fn_)
+            return sampling.sample(model, x, steps, args.eta, extra_args, callback_fn=callback_fn)
+        return sampling.cond_sample(model, x, steps, args.eta, extra_args, cond_fn_, callback_fn=callback_fn)
+
+    def run_all(n, batch_size):
+        x = torch.randn([args.n, 3, side_y, side_x], device=device)
+        t = torch.linspace(1, 0, args.steps + 1, device=device)[:-1]
+        steps = utils.get_spliced_ddpm_cosine_schedule(t)
+        if args.init:
+            steps = steps[steps < args.starting_timestep]
+            alpha, sigma = utils.t_to_alpha_sigma(steps[0])
+            x = init * alpha + x * sigma
+        for i in trange(0, n, batch_size):
+            cur_batch_size = min(n - i, batch_size)
+            outs = run(x[i:i+cur_batch_size], steps, clip_embed[i:i+cur_batch_size])
+            for j, out in enumerate(outs):
+                utils.to_pil_image(out).save(f'out_{i + j:05}.png')
+
+    try:
+        run_all(args.n, args.batch_size)
+    except KeyboardInterrupt:
+        pass
+
+
+
+def run_diffusion(prompts,images=None,steps=1000,init=None,model="yfcc_2",size=[512,512], checkpoint=None, clip_guidance_scale=500, cutn=16, cut_pow=1, device=None, eta=1.0, n=1, seed=42,starting_timestep=0.9, batch_size=1,display_freq=50):
+
+    args = SimpleNamespace(prompts=prompts,images=images,steps=steps,init=init,model=model,size=size, checkpoint=checkpoint, clip_guidance_scale=clip_guidance_scale, cutn=cutn, cut_pow=cut_pow, device=device, eta=eta, n=n, seed=seed,starting_timestep=starting_timestep, batch_size=batch_size)
+    print(args)
+    if args.device:
+        device = torch.device(args.device)
+    else:
+        device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+    print('Using device:', device)
+
+    model = get_model(args.model)()
+    _, side_y, side_x = model.shape
+    if args.size:
+        side_x, side_y = args.size
+    checkpoint = args.checkpoint
+    if not checkpoint:
+        checkpoint = MODULE_DIR / f'checkpoints/{args.model}.pth'
+    if not os.path.isfile(checkpoint):
+        download_model(args.model, checkpoint)
+    model.load_state_dict(torch.load(checkpoint, map_location='cpu'))
+    if device.type == 'cuda':
+        model = model.half()
+    model = model.to(device).eval().requires_grad_(False)
+    clip_model_name = model.clip_model if hasattr(model, 'clip_model') else 'ViT-B/16'
+    clip_model = clip.load(clip_model_name, jit=False, device=device)[0]
+    clip_model.eval().requires_grad_(False)
+    normalize = transforms.Normalize(mean=[0.48145466, 0.4578275, 0.40821073],
+                                     std=[0.26862954, 0.26130258, 0.27577711])
+    make_cutouts = MakeCutouts(clip_model.visual.input_resolution, args.cutn, args.cut_pow)
+
+    if args.init:
+        print(args.init)
+        init = Image.open(utils.fetch(args.init)).convert('RGB')
+        init = resize_and_center_crop(init, (side_x, side_y))
+        init = utils.from_pil_image(init).cuda()[None].repeat([args.n, 1, 1, 1])
+
+    target_embeds, weights = [], []
+
+    if args.prompts:
+        if isinstance(args.prompts, str):
+            args.prompts = [args.prompts,]
+        for prompt in args.prompts:
+            txt, weight = parse_prompt(prompt)
+            target_embeds.append(clip_model.encode_text(clip.tokenize(txt).to(device)).float())
+            weights.append(weight)
+
+    if args.images:
+        if isinstance(args.images, str):
+            args.images = [args.images,]
+        for prompt in args.images:
+            path, weight = parse_prompt(prompt)
+            img = Image.open(utils.fetch(path)).convert('RGB')
+            img = TF.resize(img, min(side_x, side_y, *img.size),
+                            transforms.InterpolationMode.LANCZOS)
+            batch = make_cutouts(TF.to_tensor(img)[None].to(device))
+            embeds = F.normalize(clip_model.encode_image(normalize(batch)).float(), dim=-1)
+            target_embeds.append(embeds)
+            weights.extend([weight / args.cutn] * args.cutn)
+
+    if not target_embeds:
+        raise RuntimeError('At least one text or image prompt must be specified.')
+    target_embeds = torch.cat(target_embeds)
+    weights = torch.tensor(weights, device=device)
+    if weights.sum().abs() < 1e-3:
+        raise RuntimeError('The weights must not sum to 0.')
+    weights /= weights.sum().abs()
+
+    clip_embed = F.normalize(target_embeds.mul(weights[:, None]).sum(0, keepdim=True), dim=-1)
+    clip_embed = clip_embed.repeat([args.n, 1])
+
+    torch.manual_seed(args.seed)
+
+    def callback_fn(pred, i):
+        if i % display_freq==0 or i==args.steps:
+            out = pred.add(1).div(2)
+            save_image(out, f"interm_output_{i:05d}.png")
+            if IS_NOTEBOOK:
+                display.display(display.Image(f"interm_output_{i:05d}.png",height=300))
+
+    def cond_fn(x, t, pred, clip_embed):
+        clip_in = normalize(make_cutouts((pred + 1) / 2))
+        image_embeds = clip_model.encode_image(clip_in).view([args.cutn, x.shape[0], -1])
+        losses = spherical_dist_loss(image_embeds, clip_embed[None])
+        loss = losses.mean(0).sum() * args.clip_guidance_scale
+        grad = -torch.autograd.grad(loss, x)[0]
+        return grad
+
+    def run(x, steps, clip_embed):
+        if hasattr(model, 'clip_model'):
+            extra_args = {'clip_embed': clip_embed}
+            cond_fn_ = cond_fn
+        else:
+            extra_args = {}
+            cond_fn_ = partial(cond_fn, clip_embed=clip_embed)
+        if not args.clip_guidance_scale:
+            return sampling.sample(model, x, steps, args.eta, extra_args, callback_fn=callback_fn)
+        return sampling.cond_sample(model, x, steps, args.eta, extra_args, cond_fn_, callback_fn=callback_fn)
 
     def run_all(n, batch_size):
         x = torch.randn([args.n, 3, side_y, side_x], device=device)

--- a/clip_sample.py
+++ b/clip_sample.py
@@ -77,6 +77,12 @@ def resize_and_center_crop(image, size):
     image = image.resize((int(fac * image.size[0]), int(fac * image.size[1])), Image.LANCZOS)
     return TF.center_crop(image, size[::-1])
 
+def callback_fn(info):
+    if info['i'] % 50==0:
+        out = info['pred'].add(1).div(2)
+        save_image(out, f"interm_output_{info['i']:05d}.png")
+        if IS_NOTEBOOK:
+            display.display(display.Image(f"interm_output_{info['i']:05d}.png",height=300))
 
 def main():
     p = argparse.ArgumentParser(description=__doc__,
@@ -175,13 +181,6 @@ def main():
     clip_embed = clip_embed.repeat([args.n, 1])
 
     torch.manual_seed(args.seed)
-
-    def callback_fn(pred, i):
-        if i % 50==0 or i==args.steps:
-            out = pred.add(1).div(2)
-            save_image(out, f"interm_output_{i:05d}.png")
-            if IS_NOTEBOOK:
-                display.display(display.Image(f"interm_output_{i:05d}.png",height=300))
 
     def cond_fn(x, t, pred, clip_embed):
         clip_in = normalize(make_cutouts((pred + 1) / 2))
@@ -294,13 +293,6 @@ def run_diffusion(prompts,images=None,steps=1000,init=None,model="yfcc_2",size=[
     clip_embed = clip_embed.repeat([args.n, 1])
 
     torch.manual_seed(args.seed)
-
-    def callback_fn(pred, i):
-        if i % display_freq==0 or i==args.steps:
-            out = pred.add(1).div(2)
-            save_image(out, f"interm_output_{i:05d}.png")
-            if IS_NOTEBOOK:
-                display.display(display.Image(f"interm_output_{i:05d}.png",height=300))
 
     def cond_fn(x, t, pred, clip_embed):
         clip_in = normalize(make_cutouts((pred + 1) / 2))

--- a/clip_sample.py
+++ b/clip_sample.py
@@ -201,8 +201,8 @@ def main():
             extra_args = {}
             cond_fn_ = partial(cond_fn, clip_embed=clip_embed)
         if not args.clip_guidance_scale:
-            return sampling.sample(model, x, steps, args.eta, extra_args, callback_fn=callback_fn)
-        return sampling.cond_sample(model, x, steps, args.eta, extra_args, cond_fn_, callback_fn=callback_fn)
+            return sampling.sample(model, x, steps, args.eta, extra_args, callback=callback_fn)
+        return sampling.cond_sample(model, x, steps, args.eta, extra_args, cond_fn_, callback=callback_fn)
 
     def run_all(n, batch_size):
         x = torch.randn([args.n, 3, side_y, side_x], device=device)
@@ -320,8 +320,8 @@ def run_diffusion(prompts,images=None,steps=1000,init=None,model="yfcc_2",size=[
             extra_args = {}
             cond_fn_ = partial(cond_fn, clip_embed=clip_embed)
         if not args.clip_guidance_scale:
-            return sampling.sample(model, x, steps, args.eta, extra_args, callback_fn=callback_fn)
-        return sampling.cond_sample(model, x, steps, args.eta, extra_args, cond_fn_, callback_fn=callback_fn)
+            return sampling.sample(model, x, steps, args.eta, extra_args, callback=callback_fn)
+        return sampling.cond_sample(model, x, steps, args.eta, extra_args, cond_fn_, callback=callback_fn)
 
     def run_all(n, batch_size):
         x = torch.randn([args.n, 3, side_y, side_x], device=device)

--- a/diffusion/__init__.py
+++ b/diffusion/__init__.py
@@ -1,2 +1,2 @@
 from . import sampling, utils
-from .models import get_model, get_models
+from .models import get_model, get_models, download_model

--- a/diffusion/models/__init__.py
+++ b/diffusion/models/__init__.py
@@ -1,1 +1,1 @@
-from .models import get_model, get_models
+from .models import get_model, get_models, download_model

--- a/diffusion/models/models.py
+++ b/diffusion/models/models.py
@@ -1,11 +1,20 @@
 from . import cc12m_1, yfcc_1, yfcc_2
-
+import requests
+import shutil
+import os
 
 models = {
     'cc12m_1': cc12m_1.CC12M1Model,
     'cc12m_1_cfg': cc12m_1.CC12M1Model,
     'yfcc_1': yfcc_1.YFCC1Model,
     'yfcc_2': yfcc_2.YFCC2Model,
+}
+
+model_to_url = {
+    "yfcc_2":"https://v-diffusion.s3.us-west-2.amazonaws.com/yfcc_2.pth",
+    "yfcc_1":"https://v-diffusion.s3.us-west-2.amazonaws.com/yfcc_1.pth",
+    "cc12m_1":"https://v-diffusion.s3.us-west-2.amazonaws.com/cc12m_1.pth",
+    "cc12m_1_cfg":"https://v-diffusion.s3.us-west-2.amazonaws.com/cc12m_1_cfg.pth",
 }
 
 
@@ -15,3 +24,16 @@ def get_model(model):
 
 def get_models():
     return list(models.keys())
+
+
+
+def download_model(model_name, file_path=None):
+    model_url = model_to_url[model_name]
+    if file_path is None:
+        file_path = f"checkpoints/{model_name}.pth"
+    if not os.path.exists(file_path):
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with requests.get(model_url, stream=True) as r:
+        with open(file_path, 'wb') as f:
+            shutil.copyfileobj(r.raw, f)
+

--- a/diffusion/sampling.py
+++ b/diffusion/sampling.py
@@ -1,21 +1,11 @@
 import torch
-def isnotebook():
-    try:
-        shell = get_ipython().__class__.__name__
-        return shell=='ZMQInteractiveShell' or shell=='Shell'
-    except NameError:
-        return False      
-IS_NOTEBOOK = isnotebook()
-if IS_NOTEBOOK:
-    from tqdm.notebook import trange
-else:
-    from tqdm import trange
+from tqdm.auto import trange
 
 from . import utils
 
 
 @torch.no_grad()
-def sample(model, x, steps, eta, extra_args, callback_fn=None):
+def sample(model, x, steps, eta, extra_args, callback=None):
     """Draws samples from a model given starting noise."""
     ts = x.new_ones([x.shape[0]])
 
@@ -58,7 +48,7 @@ def sample(model, x, steps, eta, extra_args, callback_fn=None):
 
 
 @torch.no_grad()
-def cond_sample(model, x, steps, eta, extra_args, cond_fn, callback_fn=None):
+def cond_sample(model, x, steps, eta, extra_args, cond_fn, callback=None):
     """Draws guided samples from a model given starting noise."""
     ts = x.new_ones([x.shape[0]])
 

--- a/diffusion/sampling.py
+++ b/diffusion/sampling.py
@@ -44,8 +44,6 @@ def sample(model, x, steps, eta, extra_args, callback=None):
             if eta:
                 x += torch.randn_like(x) * ddim_sigma
 
-        if callback_fn:
-            callback_fn(pred,i)
 
     # If we are on the last timestep, output the denoised image
     return pred
@@ -101,8 +99,6 @@ def cond_sample(model, x, steps, eta, extra_args, cond_fn, callback=None):
             if eta:
                 x += torch.randn_like(x) * ddim_sigma
 
-        if callback_fn:
-            callback_fn(pred,i)
 
     # If we are on the last timestep, output the denoised image
     return pred


### PR DESCRIPTION
- added 2 functions for cfg_sample and clip_sample, which allows calling from colab (ipython display cannot show content when using the "!" magic in notebooks)
- added a callback function for colab displays and showing intermediate results 
- added download_model function in diffusion/models/models.py, for QOL
- added a colab notebook demo